### PR TITLE
SIGTERM handling (v1.0.10)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.17)
 project(ctune
         LANGUAGES    C
-        VERSION      1.0.9
+        VERSION      1.0.10
         DESCRIPTION  "Curses based Internet radio tuner"
         HOMEPAGE_URL "eadavison.com")
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: E.A.Davison <eadavison at protonmail dot com>
 
 pkgname=ctune-git
-pkgver=v1.0.9
+pkgver=v1.0.10
 pkgrel=1
 pkgdesc="NCurses internet radio player for Linux."
 arch=('x86_64' 'aarch64')

--- a/docs/man/ctune.1.md
+++ b/docs/man/ctune.1.md
@@ -1,4 +1,4 @@
-% CTUNE(1) ctune 1.0.9
+% CTUNE(1) ctune 1.0.10
 % E.A.Davison
 % June 2021
 

--- a/src/main.c
+++ b/src/main.c
@@ -235,7 +235,11 @@ void ctune_handleSignal( int signal_id ) {
             ctune_shutdown();
             exit_curses( ERR );
             break;
-
+        case SIGTERM: //
+            CTUNE_LOG( CTUNE_LOG_MSG, "[ctune_handleSignal( %d )] Caught SIGTERM signal.", signal_id );
+            ctune_shutdown();
+            exit_curses( OK );
+            break;
         case SIGQUIT: //quit (^\)
         case SIGTSTP: //suspend (^Z)
         default:


### PR DESCRIPTION
[SRC] Added SIGTERM case to the signal handler to gracefully shutdown `ctune` when it is running on computer shutdown;