### PR TITLE
Missing directory include in CMake and added help for ubuntu 22.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,6 +476,7 @@ endif()
 
 add_executable(ctune ${SOURCE_FILES})
 add_dependencies(ctune man ctune_logger libjsonc)
+include_directories(${CMAKE_EXTERNAL_OUTPUT_DIRECTORY}/include)
 
 if(USING_FFMPEG)
     add_dependencies(ctune ctune_plugin_in_ffmpeg)

--- a/README.md
+++ b/README.md
@@ -148,6 +148,20 @@ The package is available in the AUR repository under `ctune-git`. Install using 
 >  Alternatively just download the `PKGBUILD` file into an empty staging folder and run `makepkg -si` from inside. 
    The rest should take care of itself.
 
+#### Ubuntu (>= 22.04)
+
+No PPA but here are copy/paste commands to install all the required programs and development libraries you would need before compiling `ctune`:
+
+```shell
+sudo apt-get install git cmake cmake-extras make pipewire-pulse
+```
+
+```shell
+sudo apt-get install libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libswresample-dev libavdevice-dev libavfilter-dev libssl-dev libcurl4-openssl-dev libncurses5-dev libbsd-dev libpulse-dev
+```
+
+Once all these are on the system compiling from source should work without hiccups.
+
 ## Platform
 
 Linux x64 with a UTF-8 locale.


### PR DESCRIPTION
[CMakeList.txt] Added missing directory include for the `external/include`; 
[README.md] Added some help to get the dev-libs installed for ubuntu;