### PR TITLE
Removed CMake Git check and used dedicated man install variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,12 +52,6 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 
 #========================================== PRE-CHECKS ============================================#
 find_package(PkgConfig REQUIRED)
-include(FindGit)
-find_package(Git)
-
-if (NOT Git_FOUND)
-    message(FATAL_ERROR "Required package 'Git' not found on system.")
-endif ()
 
 #======================================== LIB IMPORTS =============================================#
 # ======= #

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -46,7 +46,7 @@ add_custom_command(
 )
 
 install(FILES ${MAN_OUT_DIR}/${MAN_OUT_FILENAME_GZ}
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/man/man1
+        DESTINATION ${MAN_INSTALL_DIR}
 )
 
 install(CODE "execute_process(COMMAND ${CMAKE_SOURCE_DIR}/cmake/scripts/update_mandb.sh ARGS ${CMAKE_BUILD_TYPE})")


### PR DESCRIPTION
Hello,

In this PR, I removed the CMake check for Git since it's not used anywhere in the code and I used a dedicated CMake variable to specify the man install directory.